### PR TITLE
診断ロジックの変更

### DIFF
--- a/src/app/diagnosis/page.tsx
+++ b/src/app/diagnosis/page.tsx
@@ -23,26 +23,7 @@ export default function DiagnosisPage() {
   const [distance, setDistance] = useState(3)
   const [loading, setLoading] = useState(false)
 
-  // タイプ判定
-  const getUserType = () => {
-    if (style >= 4 && logic >= 4 && pace >= 4 && distance >= 3) {
-      return "ストイック型"
-    }
-
-    if (style <= 2 && talk >= 4 && pace <= 3 && distance <= 2) {
-      return "エンジョイ型"
-    }
-
-    if (style <= 2 && distance <= 2 && talk >= 3) {
-      return "サポート重視型"
-    }
-
-    if (talk <= 2 && pace <= 2) {
-      return "マイペース型"
-    }
-
-    return "バランス型"
-  }
+  const [resultType, setResultType] = useState<string | null>(null)
 
   const handleSubmit = async () => {
     setLoading(true)
@@ -54,9 +35,8 @@ export default function DiagnosisPage() {
         router.push("/login")
         return
       }
-
-      const type = getUserType()
-
+      
+      // サーバーへ数値を送信
       const res = await fetch(`${API_URL}/api/diagnosis`, {
         method: "POST",
         headers: {
@@ -64,7 +44,11 @@ export default function DiagnosisPage() {
           "Authorization": `Bearer ${token}`,
         },
         body: JSON.stringify({
-          user_type: type
+          style,
+          talk,
+          logic,
+          pace,
+          distance
         })
       })
 
@@ -73,7 +57,14 @@ export default function DiagnosisPage() {
         return
       }
 
-      router.push(`/diagnosis/result?type=${type}`)
+      // サーバー側で判定されたタイプを受け取る
+      const json = await res.json()
+      const type = json.user_type || json.data?.user_type
+      
+    if (type) {
+      // クエリパラメータとしてタイプを渡して遷移
+      router.push(`/diagnosis/result?type=${encodeURIComponent(type)}`)
+    }
 
     } catch (err) {
       console.error(err)

--- a/src/app/diagnosis/result/page.tsx
+++ b/src/app/diagnosis/result/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 
-import { useRouter } from "next/navigation"
+import { useRouter, useSearchParams } from "next/navigation"
+import { Suspense } from "react"
 import {
   Box,
   Typography,
@@ -9,58 +10,33 @@ import {
   Button,
   Stack
 } from "@mui/material"
-import { useEffect, useState } from "react"
 import { diagnosisMap } from "@/lib/diagnosis"
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL
 
 export default function DiagnosisResultPage() {
   const router = useRouter()
+  const searchParams = useSearchParams()
 
-  const [type, setType] = useState<string | null>(null)
-  const [loading, setLoading] = useState(true)
+  const type = searchParams.get("type")
 
-  useEffect(() => {
-    const fetchUserType = async () => {
-      try {
-        const token = localStorage.getItem("token")
-
-        if (!token) {
-          router.push("/login")
-          return
-        }
-
-        const res = await fetch(`${API_URL}/api/user`, {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        })
-
-        if (!res.ok) throw new Error("取得失敗")
-
-        const data = await res.json()
-        setType(data.user_type || null)
-
-      } catch (err) {
-        console.error(err)
-        setType(null)
-      } finally {
-        setLoading(false)
-      }
-    }
-
-    fetchUserType()
-  }, [])
-
-  const data = diagnosisMap[type ?? ""] || diagnosisMap["バランス型"]
-
-  if (loading) {
-    return <Typography p={4}>Loading...</Typography>
+  if (!type || !diagnosisMap[type]) {
+    return (
+      <Box sx={{ p: 4, textAlign: "center" }}>
+        <Typography variant="h6" color="error" mb={2}>
+          診断結果が見つかりませんでした
+        </Typography>
+        <Typography variant="body2" color="text.secondary" mb={4}>
+          もう一度最初から診断を行ってください。
+        </Typography>
+        <Button variant="contained" onClick={() => router.push("/diagnosis")}>
+          診断ページへ戻る
+        </Button>
+      </Box>
+    )
   }
 
-  if (!type) {
-    return <Typography p={4}>タイプが取得できませんでした</Typography>
-  }
+  const data = diagnosisMap[type]
 
   return (
     <Box sx={{ p: 4, maxWidth: 500, mx: "auto" }}>

--- a/src/app/diagnosis/result/page.tsx
+++ b/src/app/diagnosis/result/page.tsx
@@ -14,7 +14,7 @@ import { diagnosisMap } from "@/lib/diagnosis"
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL
 
-export default function DiagnosisResultPage() {
+function ResultContent() {
   const router = useRouter()
   const searchParams = useSearchParams()
 
@@ -83,5 +83,12 @@ export default function DiagnosisResultPage() {
         </Button>
       </Stack>
     </Box>
+  )
+}
+export default function DiagnosisResultPage() {
+  return (
+    <Suspense fallback={<Typography p={4}>Loading...</Typography>}>
+      <ResultContent />
+    </Suspense>
   )
 }


### PR DESCRIPTION
## やったこと. 
- 診断ロジックの変更

## 具体的な変更点. 
- 従来は診断結果の数値からフロントでタイプを判別していたが、数値をそのまま送り、タイプを受け取る方法に変更. 